### PR TITLE
Convert 'x-*' security types to 'apiKey'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,10 +91,16 @@ function parseSecuritySchemes(ramlSecuritySchemes) {
       if (ramlSecurityObj.type === 'OAuth 1.0')
         return;
 
-      var srType = {
-        'OAuth 2.0': 'oauth2',
-        'Basic Authentication': 'basic',
-      }[ramlSecurityObj.type];
+      //Convert 'x-*' types to 'apiKey'
+      var found = ramlSecurityObj.type.match(/^x\-/i);
+      if (found) {
+        var srType = 'apiKey';
+      } else {
+        var srType = {
+          'OAuth 2.0': 'oauth2',
+          'Basic Authentication': 'basic',
+        }[ramlSecurityObj.type];
+      }
       assert(srType);
 
       var srSecurity = {


### PR DESCRIPTION
Convert any security types starting with `x-` (see https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md#security-scheme-types , `x-{other}`) to `apiKey` (see http://swagger.io/specification/#securitySchemeObject , `type`).
## Why?

Because many RAML definitions use `x-` security types and the converter would crash on those.
