### PR TITLE
Fix: additionalProperties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -431,6 +431,15 @@ function convertSchema(schema) {
     }
   });
 
+  // Fix for adding additionalProperties to objects
+  _.each(jp.nodes(schema, '$..*["additionalProperties"]'), function(result) {
+    var value = result.value;
+    var path = result.path;
+
+    var parent = jp.value(schema, jp.stringify(_.dropRight(path)));
+    delete parent['additionalProperties'];
+  });
+
   // Fix case when arrays definition wrapped with array, like that:
   // [{
   //   "type": "array",


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
'additionalProperties' are not supported by Swagger 2.0 and therefor break conversion.

**The fix**
Resolve 'additionalProperties' to object.

Best regards,
Daniel Roth - SAP Hybris