### PR TITLE
Fix: body parameter - empty schema to be set to empty object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -334,14 +334,22 @@ function parseBody(ramlBody, srMethod) {
   if (_.isUndefined(srMethod.parameters))
     srMethod.parameters = [];
 
-  srMethod.parameters.push({
+  //Fix for the body parameter - empty schema to be set to empty object
+  //Schema is mandatory for body parameter
+  var bodyRequest = {
     //FIXME: check if name is used;
     name: 'body',
     in: 'body',
     required: true,
     //TODO: copy example
     schema: convertSchema(_.get(ramlBody[jsonMIME], 'schema'))
-  });
+  };
+
+  if (!bodyRequest.schema) {
+    bodyRequest.schema = {type: "object"};
+  }
+
+  srMethod.parameters.push(bodyRequest);
 }
 
 function convertSchema(schema) {


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
A schema is mandatory as per Open API spec for body parameters but in RAML it can be empty or undefined.

**The fix**
A schema of type object is added in case the schema is empty or undefined.

Best regards,
Daniel Roth - SAP Hybris