### PR TITLE
Fix: definitions in schema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,13 @@ exports.convert = function (raml) {
     return result;
   });
 
+  //Fix to add the inner definitions present in the schema into parent definitions
+  _.each(jp.nodes(swagger, '$..*["x-definitions"]'), function (innerSchema) {
+    _.each(innerSchema.value, function (schema, name) {
+      swagger.definitions[name] = schema;
+    });
+  });
+
   if ('mediaType' in raml) {
     swagger.consumes = [raml.mediaType];
     swagger.produces = [raml.mediaType];

--- a/src/index.js
+++ b/src/index.js
@@ -431,6 +431,12 @@ function convertSchema(schema) {
     }
   });
 
+  //Fix for definitions present in schema, renaming it to x-defintions
+  if (schema.definitions) {
+    schema["x-definitions"] = schema.definitions;
+    delete schema.definitions;
+  }
+
   // Fix case when arrays definition wrapped with array, like that:
   // [{
   //   "type": "array",


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
Inner definitions at schema level can't be referenced internally within Open API specification

**The fix**
The inner definitions have been copied into the root of the definitions of the Open API Specification.

Best regards,
Daniel Roth - SAP Hybris