### PR TITLE
Fix: empty 'required' array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -459,6 +459,17 @@ function convertSchema(schema) {
     }
   });
 
+
+  // Fix empty 'required' array
+  _.each(jp.nodes(schema, '$..required'), function(result) {
+    var name = _.last(result.path);
+    var parent = jp.value(schema, jp.stringify(_.dropRight(result.path)));
+
+    if (parent[name] instanceof Array && parent[name].length == 0) {
+      delete parent[name];
+    }
+  });
+
   // Fix case then 'items' value is empty or single element array.
   function unwrapItems(schema) {
     if (_.isEmpty(schema.items))


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
Conversion will fail if there's an empty array provided for 'required'

**The fix**
Will remove required attribute when an empty array is provided.

Best regards,
Daniel Roth - SAP Hybris