### PR TITLE
Fix: internal Uri Links and references with existing definitions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -366,6 +366,13 @@ function convertSchema(schema) {
 
   //Add '#/definitions/' prefix to all internal refs
   jp.apply(schema, '$..*["$ref"]' , function (ref) {
+    // fix internal $ref with http schema
+    if (ref.match(/^http([s]?):\/\/.*/)) {
+      return ref;
+    }
+    else if (ref.match(/^#\/definitions\//)) { // fix $ref that already has #/definitions/ inside
+      return ref;
+    }
     return '#/definitions/' + ref;
   });
 


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
1. Internal links that already have an http scheme (are a URI) would still have a '#/definitions/' put in front.
2. References that are already defined with '#/definitions/' will still get a '#/definitions/' put in front.

**The fix**
1. Will leave the link as is and not add the '#/definitions/' in front.
2. Will not add '#/definitions/' to it reference that have it already.

Best regards,
Daniel Roth - SAP Hybris