### PR TITLE
Fix: for multiple header in parameter support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -294,11 +294,12 @@ function parseParametersList(params, inValue) {
      }
 
      if (value.repeat === true) {
-       assert(['query', 'formData'].indexOf(inValue) !== -1);
+       //changes for multiple header support - added in header to the assert check
+       assert(['query', 'formData', 'header'].indexOf(inValue) !== -1);
        srParameter = {
          type: 'array',
          items: srParameter,
-         collectionFormat: 'multi'
+         collectionFormat: 'csv' // collectionFormat: 'multi' not supported for headers, use csv instead
        }
      }
 


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
Header with "collectionFormat: 'multi'" is not supported

**The fix**
Change the 'multi' to 'csv' so it accepts comma separated lists.

Best regards,
Daniel Roth - SAP Hybris