### PR TITLE
Fix: transform 'oneOf' property to object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -459,6 +459,18 @@ function convertSchema(schema) {
     }
   });
 
+  // Fix use of 'oneOf' properties, and make it type object
+  _.each(jp.nodes(schema, '$..oneOf'), function(result) {
+    var oneOfProp = 'oneOf';
+    var name = _.last(result.path);
+    var parent = jp.value(schema, jp.stringify(_.dropRight(result.path)));
+
+    if (typeof parent[oneOfProp] === 'object') {
+      parent['type'] = 'object';
+      delete parent[oneOfProp];
+    }
+  });
+
   // Fix case then 'items' value is empty or single element array.
   function unwrapItems(schema) {
     if (_.isEmpty(schema.items))


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
'oneOf' property is not supported by Swagger 2.0

**The fix**
Resolve 'oneOf' to an object in resulting Swagger spec.

Best regards,
Daniel Roth - SAP Hybris