### PR TITLE
Fix: schema ref in items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -431,6 +431,14 @@ function convertSchema(schema) {
     }
   });
 
+  //Fix for $schema in items -- Removing $schema from items
+  _.each(jp.nodes(schema, '$..properties[?(@.type === "array")]'), function (result) {
+    var value = result.value;
+    if (value.items && value.items.$schema) {
+      delete value.items.$schema;
+    }
+  });
+
   // Fix case when arrays definition wrapped with array, like that:
   // [{
   //   "type": "array",


### PR DESCRIPTION
Hi,

We, a team from SAP working on [API Hub](https://api.sap.com) and [YaaS](https://api.yaas.io), started using this converter to convert our RAML definitions into Swagger. We found that some of our RAML files were failing to convert so we had to make some changes, and we wanted to share these changes with you. We collected the list of changes we made in this [CHANGELOG](https://github.com/tehcyx/raml-to-swagger/blob/master/CHANGELOG.md) and will provide each fix as a different pull request for you so that you can pick the ones that you want to support.

**The issue to fix**
$schema present in items node of parameters/properties of type array

**The fix**
The $schema is deleted from items node of parameter and properties of type array.

Best regards,
Daniel Roth - SAP Hybris